### PR TITLE
Prevenção de possíveis erros relacionados ao Script Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ branches:
   only:
     - master
 
-script: grails -Dgeb.env=firefox test-app --non-interactive --stacktrace
+script: grails -Dgeb.env=firefox test-app functional:cucumber --non-interactive --stacktrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ branches:
   only:
     - master
 
-script: grails test-app functional:cucumber --non-interactive --stacktrace
+script: grails -Dgeb.env=firefox test-app --non-interactive --stacktrace


### PR DESCRIPTION
Previnir que erros relacionados aos testes de GUI acontecam explicitando que, no Travis, esses testes devem ser rodados utilizando o firefox. Antes dessa correção poderiam acontecer erros relacionados à criação do chromedriver.
